### PR TITLE
Add hook to add git history to each page

### DIFF
--- a/hooks/add-git-history.py
+++ b/hooks/add-git-history.py
@@ -1,3 +1,4 @@
+import re
 import subprocess
 import sys
 from typing import Union
@@ -5,21 +6,32 @@ from typing import Union
 from mkdocs.config.defaults import MkDocsConfig
 from mkdocs.structure.files import Files
 from mkdocs.structure.pages import Page
+from typing_extensions import Match
 
-exceptions = ["index", "version-history"]
+exceptions = []  # ["index", "version-history"]
+
 
 def on_page_markdown(
         markdown: str, page: Page, config: MkDocsConfig, files: Files
 ) -> Union[str, None]:
-    git_log_output = subprocess.check_output(["git", "log", "--oneline", "--", page.file.abs_src_path]).decode(sys.stdout.encoding)
     if page.file.name in exceptions:
         return markdown
     else:
+        git_hashes = (subprocess.check_output(["git", "log", "--format=%h", "--", page.file.abs_src_path])
+                      .decode(sys.stdout.encoding)
+                      .splitlines())
         commits_section = "\n\n## Page History \n\n"
-        for line in git_log_output.splitlines():
-            line_components = line.split()
-            commit_hash = line_components[0]
-            commit_message = line_components[1:]
-            commits_section += "- <a href=\"https://github.com/Minirogue/shawns-guide-to-code/commit/" + commit_hash +"\">" + commit_hash + "</a> " + " ".join(commit_message)+ "\n"
+        for commit_hash in git_hashes:
+            commit_link = "<a href=\"https://github.com/Minirogue/shawns-guide-to-code/commit/" + commit_hash + "\">" + commit_hash + "</a>"
+            commit_info = (subprocess.check_output(["git", "show", "--no-patch", "--format=\"%cs %h %s\"", commit_hash])
+                           .decode(sys.stdout.encoding))
+            commit_info = re.sub("\(#\\d+\)", lambda x: get_pr_link(x), commit_info) # add link to PR
+            commits_section += ("- " + commit_info.replace(commit_hash, commit_link)
+                                .replace("\"", ""))  # remove the vestigial quotation marks the formatting
         return markdown + commits_section
 
+
+def get_pr_link(match: Match[str]) -> str:
+    pr_number = match.group()[2:-1]
+    replacement_string = "(<a href=\"https://github.com/Minirogue/shawns-guide-to-code/pull/" + pr_number + "\">#" + pr_number + "</a>)"
+    return replacement_string

--- a/hooks/add-git-history.py
+++ b/hooks/add-git-history.py
@@ -1,0 +1,25 @@
+import subprocess
+import sys
+from typing import Union
+
+from mkdocs.config.defaults import MkDocsConfig
+from mkdocs.structure.files import Files
+from mkdocs.structure.pages import Page
+
+exceptions = ["index", "version-history"]
+
+def on_page_markdown(
+        markdown: str, page: Page, config: MkDocsConfig, files: Files
+) -> Union[str, None]:
+    git_log_output = subprocess.check_output(["git", "log", "--oneline", "--", page.file.abs_src_path]).decode(sys.stdout.encoding)
+    if page.file.name in exceptions:
+        return markdown
+    else:
+        commits_section = "\n\n## Page History \n\n"
+        for line in git_log_output.splitlines():
+            line_components = line.split()
+            commit_hash = line_components[0]
+            commit_message = line_components[1:]
+            commits_section += "- <a href=\"https://github.com/Minirogue/shawns-guide-to-code/commit/" + commit_hash +"\">" + commit_hash + "</a> " + " ".join(commit_message)+ "\n"
+        return markdown + commits_section
+

--- a/hooks/add-git-history.py
+++ b/hooks/add-git-history.py
@@ -8,7 +8,7 @@ from mkdocs.structure.files import Files
 from mkdocs.structure.pages import Page
 from typing_extensions import Match
 
-exceptions = []  # ["index", "version-history"]
+exceptions = ["index", "version-history"]
 
 
 def on_page_markdown(

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,9 @@ plugins:
   - search
   - mermaid2
 
+hooks:
+  - hooks/add-git-history.py
+
 markdown_extensions:
   - footnotes
   - pymdownx.arithmatex:


### PR DESCRIPTION
This PR adds a mkdocs hook that reads the git history for each markdown file and appends a page history to the end of that page. The history includes links to the commits as well as links to the relevant PRs if available (namely, if `(#X)` appears in the commit subject where `X` is the PR number).